### PR TITLE
Remove hardcoded Sanity token from deletePosts script

### DIFF
--- a/sanity/scripts/deletePosts.js
+++ b/sanity/scripts/deletePosts.js
@@ -5,7 +5,7 @@ const client = createClient({
     dataset: 'production',
     useCdn: false,
     apiVersion: '2025-02-19',
-    token: 'sk5T9bMoWzdyK6dsXRIOpmBYXmXmZxmcLbspeP7MJWnk4v03K9BxhQ3LtNz9aHoatIy5VeC85JtsE6PiGjKpJJAUCU95tN5PXmi0Vzwag03HVzkzUcfBc51fQRnTiQbVqLWMesVVV94p9HzIJsYOduyjLIG39uez7m6Vg5hCg7cqhirOa53k'
+    token: process.env.SANITY_API_WRITE_TOKEN || process.env.SANITY_API_READ_TOKEN
 });
 
 async function deletePosts() {


### PR DESCRIPTION
Removes the hardcoded Sanity write token from `sanity/scripts/deletePosts.js`, replacing it with `SANITY_API_WRITE_TOKEN` (matching `publishPosts.js`).

⚠️ The leaked token must still be **revoked in Sanity Manage** — removing it from code does not invalidate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
